### PR TITLE
implement referenced env var expansions

### DIFF
--- a/src/generators/generate-schema-from-env.spec.ts
+++ b/src/generators/generate-schema-from-env.spec.ts
@@ -71,4 +71,25 @@ FOO=required
 
         expect(() => generateSchemaFromEnv('nonexistent.env')).toThrow(/File not found: nonexistent\.env/);
     });
+
+    it('should generate schema for referenced variables', () => {
+        mockedExistsSync.mockReturnValue(true);
+        mockedReadFileSync.mockReturnValue(`
+# Comment line
+PORT=3000
+NEW_PORT=$PORT
+`);
+
+        mockedInferType.mockImplementation((value: string) => {
+            if (value === '3000') return 'number';
+            return '';
+        });
+
+        const result = generateSchemaFromEnv('/path/to/.env');
+
+        expect(result).toBe(`# Generated from /path/to/.env
+PORT=required|number
+NEW_PORT=required|number
+`);
+    });
 });

--- a/src/generators/generate-schema-from-env.ts
+++ b/src/generators/generate-schema-from-env.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { inferType } from './infer-type.js';
 import { SchemaEntry } from '../types.js';
+import { parseEnvContent } from '../parsers/parse-env-content.js';
 
 export function generateSchemaFromEnv(envPath: string): string {
     if (!existsSync(envPath)) {
@@ -8,22 +9,14 @@ export function generateSchemaFromEnv(envPath: string): string {
     }
 
     const raw: string = readFileSync(envPath, 'utf-8');
-    const lines: string[] = raw
-        .split(/\r?\n/)
-        .filter((line: string): boolean | '' => line.trim() && !line.startsWith('#'));
+    const env = parseEnvContent(raw);
 
-    const schemaEntries: SchemaEntry[] = lines.flatMap((line: string): SchemaEntry[] => {
-        const [keyRaw, ...valParts] = line.split('=');
-        const key: string = keyRaw.trim();
-        const value: string = valParts.join('=').trim();
-
-        if (!key || !value) return [];
-
+    const schemaEntries: SchemaEntry[] = Object.entries(env).map(([key, value]): SchemaEntry => {
         const type: 'number' | 'boolean' | '' = inferType(value);
         const rule: string = type ? `required|${type}` : 'required';
 
-        return [{ key, rule }];
-    });
+        return { key, rule }
+    })
 
     return (
         `# Generated from ${envPath}\n` +

--- a/src/parsers/parse-env-content.spec.ts
+++ b/src/parsers/parse-env-content.spec.ts
@@ -74,4 +74,39 @@ describe('parseEnvFile', () => {
             FOO: 'bar',
         });
     });
+
+    it('expands values referenced with ${VAR}', () => {
+        const result = parseEnvContent("FOO=bar\nBAR=${FOO}");
+
+        expect(result).toEqual({
+            FOO: 'bar',
+            BAR: 'bar'
+        });
+    });
+
+    it('expands values referenced with {$VAR}', () => {
+        const result = parseEnvContent("FOO=bar\nBAR={$FOO}");
+
+        expect(result).toEqual({
+            FOO: 'bar',
+            BAR: 'bar'
+        });
+    });
+
+    it('expands values referenced with $VAR', () => {
+        const result = parseEnvContent("FOO=bar\nBAR=$FOO");
+
+        expect(result).toEqual({
+            FOO: 'bar',
+            BAR: 'bar'
+        });
+    });
+
+    it('throws an error if a referenced variable does not exist', () => {
+        expect(() => parseEnvContent("FOO=bar\nBAR=$BAZ")).toThrow(`Referenced key "BAZ" not found in the env.`)
+    });
+
+    it('throws an error for self referenced variables', () => {
+        expect(() => parseEnvContent("FOO=$FOO")).toThrow(`Referenced key "FOO" not found in the env.`)
+    });
 });

--- a/src/parsers/parse-env-content.ts
+++ b/src/parsers/parse-env-content.ts
@@ -1,6 +1,9 @@
+const REFERENCE_REGEX = /(?<!\\)(\$\{(?<key1>[A-Za-z_][A-Za-z0-9_]*)\}|\{\$(?<key2>[A-Za-z_][A-Za-z0-9_]*)\}|\$(?<key3>[A-Za-z_][A-Za-z0-9_]*))/
+
 export function parseEnvContent(rawEnvContent: string): Record<string, string> {
     const env: Record<string, string> = {};
     const lines = rawEnvContent.split(/\r?\n/).filter((line) => line.trim() && !line.trim().startsWith('#'));
+    const linesWithReferences: Array<Record<string, string>> = [];
 
     for (const line of lines) {
         const [key, ...rest] = line.split('=');
@@ -13,8 +16,34 @@ export function parseEnvContent(rawEnvContent: string): Record<string, string> {
             value = value.slice(1, -1);
         }
 
+        if (REFERENCE_REGEX.test(value)) {
+            linesWithReferences.push({ key: trimmedKey, value });
+            continue;
+        }
+
         env[trimmedKey] = value;
     }
 
+    for (const line of linesWithReferences) {
+        const { key, value } = line;
+
+        env[key] = value.replace(REFERENCE_REGEX, (match) => {
+            const referencedKey = getReferencedKey(match);
+            const referencedValue = env[referencedKey];
+
+            if (referencedValue === undefined) {
+                throw new Error(`Referenced key "${referencedKey}" not found in the env.`);
+            }
+
+            return referencedValue;
+        });
+    }
+
     return env;
+}
+
+//get the referenced key from the capture groups
+function getReferencedKey(key: string): string {
+    const { groups } = REFERENCE_REGEX.exec(key)!;
+    return groups!.key1 || groups!.key2 || groups!.key3 || key;
 }


### PR DESCRIPTION
This PR adds support for expanding referenced env vars, closing #7 

It uses a regex to match  `${VAR} , $VAR , {$VAR}` as referenced variables and interpolates them correctly, throwing an exception when the values can't be resolved. This protects us from cases where variables are self-referenced or contain typos. 

@malyshev let me know what you think about this.